### PR TITLE
:gear: update CI secrets used for the build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,9 @@ on: [push]
 
 env: 
   TIPI_CACHE_FORCE_ENABLE: ON
-  TIPI_ACCESS_TOKEN: "${{ secrets.TIPI_ACCESS_TOKEN }}"
-  TIPI_REFRESH_TOKEN: "${{ secrets.TIPI_REFRESH_TOKEN }}"
-  TIPI_VAULT_PASSPHRASE: ${{ secrets.TIPI_VAULT_PASSPHRASE }}
+  TIPI_ACCESS_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
+  TIPI_REFRESH_TOKEN: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
+  TIPI_VAULT_PASSPHRASE: ${{ secrets.CLI_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
 
 jobs:
   build: 
@@ -18,5 +18,6 @@ jobs:
         uses: actions/checkout@v2
       - name: cmake-re --host builds project within tipi-container
         run: |
+          tipi connect
           cmake-re --host -S . -B ./build-host -DCMAKE_TOOLCHAIN_FILE=environments/linux.cmake
           cmake-re --build ./build-host


### PR DESCRIPTION
This fixes the minimal get-started CI.

After next release we might want to add the other cases of the README in it.