### PR TITLE
:gear: Updating get-started linux environment for v0.0.73

### DIFF
--- a/environments/linux.container.lock
+++ b/environments/linux.container.lock
@@ -1,0 +1,2 @@
+// Generated File DO NOT MANUALLY EDIT, this file SHOULD be commited to version control system
+{"image_base_name":"tipibuild/tipi-ubuntu","manifest_digest":"sha256:5d35cc63e348818f8562831ab77c914da50ff0e455105189bba72a4fd49860de","platform":"linux/amd64","raw_envzip_hash":"1bb30223868613a692740fa62d5427ca18d5ca0f"}

--- a/environments/linux.pkr.js/linux.Dockerfile
+++ b/environments/linux.pkr.js/linux.Dockerfile
@@ -1,0 +1,14 @@
+ARG UBUNTU_20_04="ubuntu@sha256:c664f8f86ed5a386b0a340d981b8f81714e21a8b9c73f658c4bea56aa179d54a"
+FROM ${UBUNTU_20_04}
+
+ENV TIPI_DISTRO_MODE=all
+ENV TIPI_INSTALL_LEGACY_PACKAGES=ON
+COPY --from=tipi /tipi-linux-x86_64.zip .
+ENV TIPI_INSTALL_SOURCE=file:///tipi-linux-x86_64.zip
+
+ARG DEBIAN_FRONTEND=noninteractive # avoid tzdata asking for configuration
+# Install tipi and cmake-re
+
+RUN apt update -y && apt install -y curl gettext
+RUN curl -fsSL https://raw.githubusercontent.com/tipi-build/cli/c14014db11342118f65ef95520a70f43c17ca453/install/container/ubuntu.sh -o ubuntu.sh && /bin/bash ubuntu.sh
+EXPOSE 22

--- a/environments/linux.pkr.js/linux.pkr.js
+++ b/environments/linux.pkr.js/linux.pkr.js
@@ -3,7 +3,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu@sha256:0b9d9f10eb807faec9d450e476a7721b3f085a7a716f17cf345130e3d94d9094",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
   ],
@@ -14,7 +14,4 @@
       "tag": "latest"
     }
   ]
-  ,"_tipi_version":"{{tipi_version_hash}}"
-
-
 }


### PR DESCRIPTION
This  syncs the official tipi environment https://github.com/tipi-build/environments/blob/main/linux.pkr.js/linux.pkr.js as locked container in get-started.