### PR TITLE
:gear: Bump environment lock file for cmake-re v0.0.74

### DIFF
--- a/environments/linux.container.lock
+++ b/environments/linux.container.lock
@@ -1,2 +1,2 @@
 // Generated File DO NOT MANUALLY EDIT, this file SHOULD be commited to version control system
-{"image_base_name":"tipibuild/tipi-ubuntu","manifest_digest":"sha256:5d35cc63e348818f8562831ab77c914da50ff0e455105189bba72a4fd49860de","platform":"linux/amd64","raw_envzip_hash":"1bb30223868613a692740fa62d5427ca18d5ca0f"}
+{"image_base_name":"tipibuild/tipi-ubuntu","manifest_digest":"sha256:b2a9606b584ec13dd22eb192e0d262a8b58b0e8d4035c8624cdddeceddc29aaf","platform":"linux/amd64","raw_envzip_hash":"25477f3bbbfc32659cc291b53074ebb5642c2177"}

--- a/environments/linux.pkr.js/linux.pkr.js
+++ b/environments/linux.pkr.js/linux.pkr.js
@@ -6,12 +6,5 @@
       "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    { 
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
   ]
 }


### PR DESCRIPTION
This stores an environment lock files which matches the released one and removed the now unneeded pkr.js post-processor section.